### PR TITLE
Removed a self-introduced bug

### DIFF
--- a/YouVsVirus/Assets/Scripts/Components/CreatePopulation.cs
+++ b/YouVsVirus/Assets/Scripts/Components/CreatePopulation.cs
@@ -86,7 +86,6 @@ namespace Components
             {
                 NPCs[i].SetInitialCondition(NPC.EXPOSED);
             }
-
             GameObject.Find("EndGameController").GetComponent<EndGameController>().InitComplete();
         }
 

--- a/YouVsVirus/Assets/Scripts/Components/HumanBase.cs
+++ b/YouVsVirus/Assets/Scripts/Components/HumanBase.cs
@@ -31,12 +31,21 @@ namespace Components
         public const int DEAD        = 4;
 
 
-        
+        /// <summary>
+        /// This human's inital condition
+        /// </summary>
+        protected int _initialCondition = WELL;
+
         /// <summary>
         /// Set the human's initial condition
+        /// Default: well
+        /// This function is called by base classes even before Start() who are allowed
+        /// to modify _initialCondition in advance. In Start() the _initialCondition
+        /// value ist transferred to _mycondition
         /// </summary>
         public void SetInitialCondition(int condition)
         {
+            _initialCondition = condition;
             _mycondition = condition;
         }
 
@@ -149,6 +158,9 @@ namespace Components
             myRigidbody = GetComponent<Rigidbody2D>();
             // The player and npc class set their corresponding sprite images
             SetSpriteImages();
+            // _initialCondition may have been modified by base classes
+            // this becomes _mycondition during Start()
+            SetCondition(_initialCondition);
         }
 
 

--- a/YouVsVirus/Assets/Scripts/Components/HumanBase.cs
+++ b/YouVsVirus/Assets/Scripts/Components/HumanBase.cs
@@ -31,21 +31,13 @@ namespace Components
         public const int DEAD        = 4;
 
 
-        /// <summary>
-        /// This human's inital condition
-        /// </summary>
-        protected int _initialCondition = WELL;
-
+        
         /// <summary>
         /// Set the human's initial condition
-        /// Default: well
-        /// This function is called by base classes even before Start() who are allowed
-        /// to modify _initialCondition in advance. In Start() the _initialCondition
-        /// value ist transferred to _mycondition
         /// </summary>
         public void SetInitialCondition(int condition)
         {
-            _initialCondition = condition;
+            _mycondition = condition;
         }
 
         /// <summary>
@@ -157,9 +149,6 @@ namespace Components
             myRigidbody = GetComponent<Rigidbody2D>();
             // The player and npc class set their corresponding sprite images
             SetSpriteImages();
-            // _initialCondition may have been modified by base classes
-            // this becomes _mycondition during Start()
-            SetCondition(_initialCondition);
         }
 
 


### PR DESCRIPTION
The  NPCs set their initial condition which was only later on Start() transfered
to the human's condition. Hence the  NPC  list itself did not store  the
right condition (exposed). This was no problem since we did not really do
anything with the list - until now where I tried to use it.