### PR TITLE
Margrit/game ended early

### DIFF
--- a/YouVsVirus/.gitignore
+++ b/YouVsVirus/.gitignore
@@ -68,3 +68,6 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# VS Code
+**/.vscode

--- a/YouVsVirus/Assets/Scripts/Components/CreatePopulation.cs
+++ b/YouVsVirus/Assets/Scripts/Components/CreatePopulation.cs
@@ -86,7 +86,6 @@ namespace Components
             {
                 NPCs[i].SetInitialCondition(NPC.EXPOSED);
             }
-            GameObject.Find("EndGameController").GetComponent<EndGameController>().InitComplete();
         }
 
 

--- a/YouVsVirus/Assets/Scripts/Components/CreatePopulation.cs
+++ b/YouVsVirus/Assets/Scripts/Components/CreatePopulation.cs
@@ -39,8 +39,8 @@ namespace Components
             NPCs = new List<NPC>(30);
         }
 
-        // Start is called before the first frame update
-        void Start()
+        // Awake is called the moment this component is created
+        void Awake()
         {
             levelSettings = LevelSettings.GetActiveLevelSettings();
 
@@ -150,7 +150,7 @@ namespace Components
         private int[] ChooseUnique(int N, int from, int to)
         {
             int count = to - from;
-            if (to - from < count) throw new ArgumentException("N was larger than the range! ");
+            if (count < N) throw new ArgumentException("N was larger than the range! ");
 
             int[] indices = Enumerable.Range(from, count).ToArray();
             shuffleInPlace(indices);

--- a/YouVsVirus/Assets/Scripts/Components/CreatePopulation.cs.meta
+++ b/YouVsVirus/Assets/Scripts/Components/CreatePopulation.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 100
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/YouVsVirus/Assets/Scripts/Components/EndGameController.cs
+++ b/YouVsVirus/Assets/Scripts/Components/EndGameController.cs
@@ -89,8 +89,14 @@ public class EndGameController : MonoBehaviour
 
     void Update()
     {
+
         //  Do nothing before initialization has not been completed
         if (!initComplete) return;
+
+        if (Input.GetKeyDown(KeyCode.Escape))
+        {
+            EndGame();
+        }
 
         //  The game is already ending, so just do nothing and wait.
         if (endConditionMet) return;
@@ -129,6 +135,5 @@ public class EndGameController : MonoBehaviour
     private bool CheckEndCondition()
     {
         return playerDied || activeInfections == 0;
-
     }
 }

--- a/YouVsVirus/Assets/Scripts/Components/EndGameController.cs
+++ b/YouVsVirus/Assets/Scripts/Components/EndGameController.cs
@@ -25,21 +25,10 @@ public class EndGameController : MonoBehaviour
     //  Has an end condition been met?
     private bool endConditionMet = false;
 
-    private bool initComplete = false;
-
     public void Start()
     {
         // Remember the starting time to check for the timeout end condition
         startTime = Time.time;
-    }
-
-    /// <summary>
-    /// Notify the end game controller that level initialization has been completed.
-    /// Otherwise, it might end the game before it has begun.
-    /// </summary>
-    public void InitComplete()
-    {
-        initComplete = true;
     }
 
     /// <summary>
@@ -74,7 +63,7 @@ public class EndGameController : MonoBehaviour
     /// <summary>
     /// Notify the end game controller that an NPC has been exposed
     /// </summary>
-    public void NotifyNPCExposed()
+    public void NotifyHumanExposed()
     {
         activeInfections++;
     }
@@ -82,16 +71,13 @@ public class EndGameController : MonoBehaviour
     /// <summary>
     /// Notify the end game controller that an NPC has either recovered or died.
     /// </summary>
-    public void NotifyNPCRemoved()
+    public void NotifyHumanRemoved()
     {
         activeInfections--;
     }
 
     void Update()
     {
-
-        //  Do nothing before initialization has not been completed
-        if (!initComplete) return;
 
         if (Input.GetKeyDown(KeyCode.Escape))
         {

--- a/YouVsVirus/Assets/Scripts/Components/EndGameController.cs.meta
+++ b/YouVsVirus/Assets/Scripts/Components/EndGameController.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 200
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/YouVsVirus/Assets/Scripts/Components/HumanBase.cs
+++ b/YouVsVirus/Assets/Scripts/Components/HumanBase.cs
@@ -78,33 +78,15 @@ namespace Components
         public virtual void SetCondition(int condition)
         {
             _mycondition = condition;
-
-            if(_mycondition == DEAD)
-            {
-                //  Removes this human's Rigidbody from the physics simulation, 
-                //  which disables movement and collision detection.
-                myRigidbody.simulated = false;
-
-                //  Set the simulated velocity to zero.
-                myRigidbody.velocity = Vector3.zero;
-
-                //  Put this human's sprite on the 'Dead' sorting layer.
-                //  This layer is below the others, causing Dead humans to be rendered
-                //  below the living.
-                GetComponent<SpriteRenderer>().sortingLayerName = "Dead";
-            }
-
-            if(_mycondition == EXPOSED)
-            {
-                //  Notify our infection model that we've been exposed
-                GetComponent<AbstractInfection>().Expose();
-            }
+            EndGameController egc = GameObject.Find("EndGameController").GetComponent<EndGameController>();
 
             // Update the stats
             switch (condition)
             {
                 case EXPOSED:
                     {
+                        egc.NotifyHumanExposed();
+                        GetComponent<AbstractInfection>().Expose();
                         levelStats.aHumanGotExposed();
                         break;
                     }
@@ -115,11 +97,25 @@ namespace Components
                     }
                 case DEAD:
                     {
+                        //  Removes this human's Rigidbody from the physics simulation, 
+                        //  which disables movement and collision detection.
+                        myRigidbody.simulated = false;
+
+                        //  Set the simulated velocity to zero.
+                        myRigidbody.velocity = Vector3.zero;
+
+                        //  Put this human's sprite on the 'Dead' sorting layer.
+                        //  This layer is below the others, causing Dead humans to be rendered
+                        //  below the living.
+                        GetComponent<SpriteRenderer>().sortingLayerName = "Dead";
+
+                        egc.NotifyHumanRemoved();
                         levelStats.aHumanDied();
                         break;
                     }
                 case RECOVERED:
                     {
+                        egc.NotifyHumanRemoved();
                         levelStats.aHumanRecovered();
                         break;
                     }
@@ -161,7 +157,6 @@ namespace Components
             // _initialCondition may have been modified by base classes
             // this becomes _mycondition during Start()
             SetCondition(_initialCondition);
-            GameObject.Find("EndGameController").GetComponent<EndGameController>().InitComplete();
         }
 
 

--- a/YouVsVirus/Assets/Scripts/Components/HumanBase.cs
+++ b/YouVsVirus/Assets/Scripts/Components/HumanBase.cs
@@ -161,6 +161,7 @@ namespace Components
             // _initialCondition may have been modified by base classes
             // this becomes _mycondition during Start()
             SetCondition(_initialCondition);
+            GameObject.Find("EndGameController").GetComponent<EndGameController>().InitComplete();
         }
 
 

--- a/YouVsVirus/Assets/Scripts/Components/HumanBase.cs.meta
+++ b/YouVsVirus/Assets/Scripts/Components/HumanBase.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 50
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/YouVsVirus/Assets/Scripts/Components/NPC.cs
+++ b/YouVsVirus/Assets/Scripts/Components/NPC.cs
@@ -53,23 +53,6 @@ namespace Components
             }
         }
 
-        public override void SetCondition(int condition)
-        {
-            base.SetCondition(condition);
-
-            EndGameController egc = GameObject.Find("EndGameController").GetComponent<EndGameController>();
-
-            if (condition == EXPOSED)
-            {
-                egc.NotifyNPCExposed();
-            }
-
-            if(condition == DEAD || condition == RECOVERED)
-            {
-                egc.NotifyNPCRemoved();
-            }
-        }
-
         /// <summary>
         /// Sprite images corresponding to infections states of npc
         /// </summary>


### PR DESCRIPTION
Sometimes after restart in the endscreen, the game just ended . This was probably due to
activeInfections=0 and initComplete = true.
* moved initComplete to HumansBase (after the SetCondiion function calls activeInfections++)
* in the proect setting: call first HumaneBase, then CreatePopulation, then EndGameController
* added Esc-key to end game whenever the user wants
* this worked now in  quite a number of runs, but I am not entirely sure this is fixed now because it occured randomly