### PR TITLE
Johannes/additional data folder

### DIFF
--- a/AdditionalData/README.md
+++ b/AdditionalData/README.md
@@ -1,9 +1,17 @@
+## AdditionalData
+
 In this folder we collect data that is important for the project, but should not show up in the unity editor.
 For example .svg files to .png sprites for later modification.
 
 If you add a file here that is somehow associated to a file inside the YouVsVirus folder, please add a note here,
-to which file it is associated.
+to which file it is associated and how.
 If you create a new folder, please add a README with a corresponding list in that folder.
 
 
-Data	Associated to	Note
+### Data in this folder
+
+|Data                   |	Associated to	         |  Note       |
+|-----------------------|-----------------------:|------------:|
+|ExampleFile1.bla       | Assets/Sprites/Ui.meta | This item does not exist. This row serves as an example entry. |
+|                       |                        |             |
+|                       |                        |             |

--- a/AdditionalData/README.md
+++ b/AdditionalData/README.md
@@ -1,0 +1,9 @@
+In this folder we collect data that is important for the project, but should not show up in the unity editor.
+For example .svg files to .png sprites for later modification.
+
+If you add a file here that is somehow associated to a file inside the YouVsVirus folder, please add a note here,
+to which file it is associated.
+If you create a new folder, please add a README with a corresponding list in that folder.
+
+
+Data	Associated to	Note


### PR DESCRIPTION
It became clear that we need a space to but data into that should not show up in the unity editor.
Commonly these are raw files to images that we use, such as .svg files etc.

I added  a new folder, outside of the unity folder where we can place this data.
If we add data here that is associated to a unity image or asset or something inside the unity folder, we should specify this in the README file.