### PR TITLE
Add a new prefab nonSpawnable space

### DIFF
--- a/YouVsVirus/Assets/Materials/Physics/HumanColliderMat.physicsMaterial2D
+++ b/YouVsVirus/Assets/Materials/Physics/HumanColliderMat.physicsMaterial2D
@@ -7,5 +7,5 @@ PhysicsMaterial2D:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: HumanColliderMat
-  friction: 0.5
-  bounciness: 0.5
+  friction: 0.82
+  bounciness: 0.82

--- a/YouVsVirus/Assets/Materials/Physics/HumanColliderMat.physicsMaterial2D
+++ b/YouVsVirus/Assets/Materials/Physics/HumanColliderMat.physicsMaterial2D
@@ -7,5 +7,5 @@ PhysicsMaterial2D:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: HumanColliderMat
-  friction: 0.82
-  bounciness: 0.82
+  friction: 0.5
+  bounciness: 0.5

--- a/YouVsVirus/Assets/Resources/nonSpawnableSpace.prefab
+++ b/YouVsVirus/Assets/Resources/nonSpawnableSpace.prefab
@@ -1,0 +1,62 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8582084674378809926
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8582084674378809921}
+  - component: {fileID: 8582084674378809920}
+  - component: {fileID: 8582084674378809927}
+  m_Layer: 14
+  m_Name: nonSpawnableSpace
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8582084674378809921
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8582084674378809926}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.7431851, y: 0.44068825, z: -3.2089844}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &8582084674378809920
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8582084674378809926}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 1.3034225}
+  serializedVersion: 2
+  m_Radius: 1.8034225
+--- !u!114 &8582084674378809927
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8582084674378809926}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 811f6eef37793e844aba40791ebb698f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/YouVsVirus/Assets/Resources/nonSpawnableSpace.prefab.meta
+++ b/YouVsVirus/Assets/Resources/nonSpawnableSpace.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 13f8679b8143423459b1377f46310d7d
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/YouVsVirus/Assets/Scenes/Levelgethome/YouVsVirus_Levelgethome.unity
+++ b/YouVsVirus/Assets/Scenes/Levelgethome/YouVsVirus_Levelgethome.unity
@@ -398,7 +398,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1083008139
-  m_SortingLayer: -4
+  m_SortingLayer: -5
   m_SortingOrder: 1
   m_Sprite: {fileID: 21300000, guid: 0312f9a192964c2488501cec6c9a5b47, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -963,11 +963,11 @@ EdgeCollider2D:
   m_Offset: {x: 0, y: 0}
   m_EdgeRadius: 0
   m_Points:
-  - {x: -8.874203, y: -5}
-  - {x: -8.874203, y: 5}
-  - {x: 8.874203, y: 5}
-  - {x: 8.874203, y: -5}
-  - {x: -8.874203, y: -5}
+  - {x: -8.889803, y: -5}
+  - {x: -8.889803, y: 5}
+  - {x: 8.889803, y: 5}
+  - {x: 8.889803, y: -5}
+  - {x: -8.889803, y: -5}
 --- !u!20 &519420031
 Camera:
   m_ObjectHideFlags: 0
@@ -987,9 +987,9 @@ Camera:
   m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
-    x: 0.00044605136
+    x: 0.000051379204
     y: 0
-    width: 0.9991079
+    width: 0.99989724
     height: 1
   near clip plane: 0.3
   far clip plane: 1000
@@ -1321,6 +1321,12 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 654525689}
   m_CullTransparentMesh: 0
+--- !u!1 &702865890 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8582084674378809926, guid: 13f8679b8143423459b1377f46310d7d,
+    type: 3}
+  m_PrefabInstance: {fileID: 8582084673986405284}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &742637914
 GameObject:
   m_ObjectHideFlags: 0
@@ -1354,6 +1360,7 @@ MonoBehaviour:
     type: 3}
   npcPrefab: {fileID: 8900475433866948943, guid: ab9d2a99c32f65a43a4c99a9379ce533,
     type: 3}
+  nonSpawnableSpaceObj: {fileID: 702865890}
 --- !u!4 &742637916
 Transform:
   m_ObjectHideFlags: 0
@@ -2295,7 +2302,7 @@ Camera:
   m_TargetDisplay: 0
   m_TargetEye: 3
   m_HDR: 1
-  m_AllowMSAA: 1
+  m_AllowMSAA: 0
   m_AllowDynamicResolution: 0
   m_ForceIntoRT: 0
   m_OcclusionCulling: 1
@@ -2527,7 +2534,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1083008139
-  m_SortingLayer: -4
+  m_SortingLayer: -5
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: e6c80e7cff6cb87498205bc868b2b964, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -2890,3 +2897,87 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1001 &8582084673986405284
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8582084674378809920, guid: 13f8679b8143423459b1377f46310d7d,
+        type: 3}
+      propertyPath: m_Offset.x
+      value: 7.41
+      objectReference: {fileID: 0}
+    - target: {fileID: 8582084674378809920, guid: 13f8679b8143423459b1377f46310d7d,
+        type: 3}
+      propertyPath: m_Offset.y
+      value: -4.48
+      objectReference: {fileID: 0}
+    - target: {fileID: 8582084674378809920, guid: 13f8679b8143423459b1377f46310d7d,
+        type: 3}
+      propertyPath: m_Radius
+      value: 1.64
+      objectReference: {fileID: 0}
+    - target: {fileID: 8582084674378809921, guid: 13f8679b8143423459b1377f46310d7d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.7431851
+      objectReference: {fileID: 0}
+    - target: {fileID: 8582084674378809921, guid: 13f8679b8143423459b1377f46310d7d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.44068825
+      objectReference: {fileID: 0}
+    - target: {fileID: 8582084674378809921, guid: 13f8679b8143423459b1377f46310d7d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3.2089844
+      objectReference: {fileID: 0}
+    - target: {fileID: 8582084674378809921, guid: 13f8679b8143423459b1377f46310d7d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8582084674378809921, guid: 13f8679b8143423459b1377f46310d7d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8582084674378809921, guid: 13f8679b8143423459b1377f46310d7d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8582084674378809921, guid: 13f8679b8143423459b1377f46310d7d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8582084674378809921, guid: 13f8679b8143423459b1377f46310d7d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 8582084674378809921, guid: 13f8679b8143423459b1377f46310d7d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8582084674378809921, guid: 13f8679b8143423459b1377f46310d7d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8582084674378809921, guid: 13f8679b8143423459b1377f46310d7d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8582084674378809926, guid: 13f8679b8143423459b1377f46310d7d,
+        type: 3}
+      propertyPath: m_Name
+      value: nonSpawnableSpace
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 13f8679b8143423459b1377f46310d7d, type: 3}

--- a/YouVsVirus/Assets/Scripts/Components/HumanInstants.cs
+++ b/YouVsVirus/Assets/Scripts/Components/HumanInstants.cs
@@ -40,6 +40,8 @@ namespace Components
 
         private RandomGrid randomGridForHumans;
 
+        public nonSpawnableSpace nonSpawnable;
+
 
         // Start is called before the first frame update
         void Start()
@@ -57,7 +59,7 @@ namespace Components
             // and the number of humans that we want to place
             randomGridForHumans.GenerateRandomCoords(playerPrefab.transform.localScale.x,
                                                             playerPrefab.GetComponentInChildren<InfectionTrigger>().InfectionRadius,
-                                                            npcNumber);
+                                                            npcNumber, nonSpawnable.GetComponent<nonSpawnableSpace>());
             // place humans on the grid
             CreateHumans();
         }

--- a/YouVsVirus/Assets/Scripts/Components/HumanInstants.cs
+++ b/YouVsVirus/Assets/Scripts/Components/HumanInstants.cs
@@ -59,7 +59,7 @@ namespace Components
             // and the number of humans that we want to place
             randomGridForHumans.GenerateRandomCoords(playerPrefab.transform.localScale.x,
                                                             playerPrefab.GetComponentInChildren<InfectionTrigger>().InfectionRadius,
-                                                            npcNumber, nonSpawnable.GetComponent<nonSpawnableSpace>());
+                                                            npcNumber);
             // place humans on the grid
             CreateHumans();
         }

--- a/YouVsVirus/Assets/Scripts/Components/RandomGrid.cs
+++ b/YouVsVirus/Assets/Scripts/Components/RandomGrid.cs
@@ -84,6 +84,7 @@ namespace Components
             const int maxAttempts = 50;
             while (notAllAreSpawnable && countAttempt < maxAttempts) 
             {
+                Debug.Log ("Attempting to spawn humans. Attemp #" + countAttempt);
                 //  Randomly select grid indices
                 indices = ChooseUnique(npcNumber + 1, 0, cellCount);
 
@@ -97,6 +98,7 @@ namespace Components
                         notAllAreSpawnable = true;
                     }
                 }
+                countAttempt++;
             }
             for (int i = 0; i < npcNumber + 1; i++)
             {

--- a/YouVsVirus/Assets/Scripts/Components/RandomGrid.cs
+++ b/YouVsVirus/Assets/Scripts/Components/RandomGrid.cs
@@ -45,10 +45,39 @@ namespace Components
             screenBounds = MainCamera.GetComponent<CameraResolution>().GetMapExtents();
         }
 
+        /// <summary>
+        /// compute a list of random coords generated so that all prefab clones
+        /// are placed on a grid in safe distance from each other
+        /// <param name="scale"> e.g. the player's scale needed for grid size </param>
+        /// <param name="infection_radius"> e.g. the player's infection radius for grid size </param>
+        /// <param name="npcNumber"> number of prefabs clones to be placed, player is +1 </param>
+        /// </summary>
+        public void GenerateRandomCoords(float scale, float infection_radius, int npcNumber)
+        {
+            //  Determine the size of a single cell
+            float cellRadius = GetCellRadius(scale, infection_radius);
+            float cellSidelength = 2f * cellRadius;
+
+            //  Determine the total size of the grid
+            int[] gridSize = GetGridSize(cellSidelength);
+            int rows = gridSize[0];
+            int columns = gridSize[1];
+            int cellCount = rows * columns;
+
+            //  Randomly select grid indices
+            int[] indices = ChooseUnique(npcNumber + 1, 0, cellCount);
+
+            Vector2 origin = -screenBounds;
+            for (int i = 0; i < npcNumber + 1; i++)
+            {
+                RandomCoords.Add(GetCoordinatesInGrid(indices[i], columns, cellRadius, origin));
+            }
+        }
 
         /// <summary>
         /// compute a list of random coords generated so that all prefab clones
         /// are placed on a grid in safe distance from each other
+        /// including space where NPCs are not allowed to spawn
         /// <param name="scale"> e.g. the player's scale needed for grid size </param>
         /// <param name="infection_radius"> e.g. the player's infection radius for grid size </param>
         /// <param name="npcNumber"> number of prefabs clones to be placed, player is +1 </param>

--- a/YouVsVirus/Assets/Scripts/Components/RandomGrid.cs
+++ b/YouVsVirus/Assets/Scripts/Components/RandomGrid.cs
@@ -52,8 +52,9 @@ namespace Components
         /// <param name="scale"> e.g. the player's scale needed for grid size </param>
         /// <param name="infection_radius"> e.g. the player's infection radius for grid size </param>
         /// <param name="npcNumber"> number of prefabs clones to be placed, player is +1 </param>
+        /// <param name="nonSpawnable"> space in which no NPC should spawn </param>
         /// </summary>
-        public void GenerateRandomCoords(float scale, float infection_radius, int npcNumber)
+        public void GenerateRandomCoords(float scale, float infection_radius, int npcNumber, nonSpawnableSpace nonSpawnable)
         {
             //  Determine the size of a single cell
             float cellRadius = GetCellRadius(scale, infection_radius);
@@ -64,11 +65,39 @@ namespace Components
             int rows = gridSize[0];
             int columns = gridSize[1];
             int cellCount = rows * columns;
-
-            //  Randomly select grid indices
-            int[] indices = ChooseUnique(npcNumber + 1, 0, cellCount);
+            bool notAllAreSpawnable = true;
 
             Vector2 origin = -screenBounds;
+
+            // Create random coordinates until all are in spawnable space
+            // This way it is really ineffective, because we create all coords and
+            // then check if they are spawnable and if not create all again.
+            // However, we should take the isSpawnable check into ChooseUnique
+            // and i currently do not know how to do this.
+            //
+            // Since this may crash the program, either because it just
+            // takes too long, or because the spawnable space is just too small to
+            // spawn all smileys, we give up after 50 attempts and just use
+            // the last configuration. Even though some may now live in unspawnable space.
+            int[] indices = null;
+            int countAttempt = 0;
+            const int maxAttempts = 50;
+            while (notAllAreSpawnable && countAttempt < maxAttempts) 
+            {
+                //  Randomly select grid indices
+                indices = ChooseUnique(npcNumber + 1, 0, cellCount);
+
+                notAllAreSpawnable = false;
+                for (int i = 0; i < npcNumber + 1; i++)
+                {
+                    if (!nonSpawnable.coordinatesAreSpawnable2D(GetCoordinatesInGrid(indices[i], columns, cellRadius, origin)))
+                    {
+                        // This NPC is non-spawnable. Set notAllAreSpawnable to true and exit the for loop (by setting i = npcNumber, (i dont like break))
+                        i = npcNumber;
+                        notAllAreSpawnable = true;
+                    }
+                }
+            }
             for (int i = 0; i < npcNumber + 1; i++)
             {
                 RandomCoords.Add(GetCoordinatesInGrid(indices[i], columns, cellRadius, origin));

--- a/YouVsVirus/Assets/Scripts/Components/nonSpawnableSpace.cs
+++ b/YouVsVirus/Assets/Scripts/Components/nonSpawnableSpace.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+// The nonSpawnableSpace class serves the purpose to
+// defines regions on the map that are non-spawnable.
+// Attach cirlceColliders to the game object that define
+// space where nothing should spawn.
+// If you then call the function coordinatesAreSpawnable2D with
+// a coordinate vector it will return false if the coordinates 
+// lie within the circles and true if they lie outside.
+namespace Components
+{
+public class nonSpawnableSpace : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+    public bool coordinatesAreSpawnable2D (Vector2 coord2D)
+    {
+        CircleCollider2D[] colliders2D;
+
+        colliders2D = GetComponents<CircleCollider2D>();
+        foreach (CircleCollider2D collider in colliders2D) {
+            // Build a 2D vector with the colliders 2D center coordinates.
+            Vector2 colliderCenter = new Vector2(collider.offset[0] + transform.position[0],
+                                                 collider.offset[1] + transform.position[1]);
+            
+            Debug.Log ("SpawnableSpace: Circle with center " + colliderCenter + " and radius " + collider.radius);
+            Debug.Log ("SpawnableSpace: checking agains point " + coord2D);
+
+            if (Vector2.Distance (coord2D, colliderCenter) < collider.radius) {
+                // The coordinates lie within the collider
+                // This coordinate is non-spawnable
+                Debug.Log ("SpawnableSpace: Non spawnable");
+                return false;
+            }
+        }
+                Debug.Log ("SpawnableSpace: spawnable");
+        return true;
+    }
+}
+}

--- a/YouVsVirus/Assets/Scripts/Components/nonSpawnableSpace.cs
+++ b/YouVsVirus/Assets/Scripts/Components/nonSpawnableSpace.cs
@@ -25,6 +25,14 @@ public class nonSpawnableSpace : MonoBehaviour
         
     }
 
+    /// <summary>
+    /// Given a 2D vector of coordinates, check whether the coordinates
+    /// are within the nonSpawnable space defined by the associated
+    /// circle colliders.
+    /// </summary>
+    /// <returns> True if the coordinates are outside of the nonSpawnable space.
+    /// False otherwise.
+    /// </returns>
     public bool coordinatesAreSpawnable2D (Vector2 coord2D)
     {
         CircleCollider2D[] colliders2D;

--- a/YouVsVirus/Assets/Scripts/Components/nonSpawnableSpace.cs
+++ b/YouVsVirus/Assets/Scripts/Components/nonSpawnableSpace.cs
@@ -38,7 +38,7 @@ public class nonSpawnableSpace : MonoBehaviour
                                                     collider.offset[1] + transform.position[1]);
                 
                 Debug.Log ("SpawnableSpace: Circle with center " + colliderCenter + " and radius " + collider.radius);
-                Debug.Log ("SpawnableSpace: checking agains point " + coord2D);
+                Debug.Log ("SpawnableSpace: checking against point " + coord2D);
 
                 if (Vector2.Distance (coord2D, colliderCenter) < collider.radius) {
                     // The coordinates lie within the collider

--- a/YouVsVirus/Assets/Scripts/Components/nonSpawnableSpace.cs
+++ b/YouVsVirus/Assets/Scripts/Components/nonSpawnableSpace.cs
@@ -13,17 +13,6 @@ namespace Components
 {
 public class nonSpawnableSpace : MonoBehaviour
 {
-    // Start is called before the first frame update
-    void Start()
-    {
-        
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        
-    }
 
     public bool coordinatesAreSpawnable2D (Vector2 coord2D)
     {

--- a/YouVsVirus/Assets/Scripts/Components/nonSpawnableSpace.cs
+++ b/YouVsVirus/Assets/Scripts/Components/nonSpawnableSpace.cs
@@ -31,21 +31,24 @@ public class nonSpawnableSpace : MonoBehaviour
 
         colliders2D = GetComponents<CircleCollider2D>();
         foreach (CircleCollider2D collider in colliders2D) {
-            // Build a 2D vector with the colliders 2D center coordinates.
-            Vector2 colliderCenter = new Vector2(collider.offset[0] + transform.position[0],
-                                                 collider.offset[1] + transform.position[1]);
-            
-            Debug.Log ("SpawnableSpace: Circle with center " + colliderCenter + " and radius " + collider.radius);
-            Debug.Log ("SpawnableSpace: checking agains point " + coord2D);
+            if (collider.isActiveAndEnabled)
+            {
+                // Build a 2D vector with the colliders 2D center coordinates.
+                Vector2 colliderCenter = new Vector2(collider.offset[0] + transform.position[0],
+                                                    collider.offset[1] + transform.position[1]);
+                
+                Debug.Log ("SpawnableSpace: Circle with center " + colliderCenter + " and radius " + collider.radius);
+                Debug.Log ("SpawnableSpace: checking agains point " + coord2D);
 
-            if (Vector2.Distance (coord2D, colliderCenter) < collider.radius) {
-                // The coordinates lie within the collider
-                // This coordinate is non-spawnable
-                Debug.Log ("SpawnableSpace: Non spawnable");
-                return false;
+                if (Vector2.Distance (coord2D, colliderCenter) < collider.radius) {
+                    // The coordinates lie within the collider
+                    // This coordinate is non-spawnable
+                    Debug.Log ("SpawnableSpace: Non spawnable");
+                    return false;
+                }
             }
         }
-                Debug.Log ("SpawnableSpace: spawnable");
+        Debug.Log ("SpawnableSpace: spawnable");
         return true;
     }
 }

--- a/YouVsVirus/Assets/Scripts/Components/nonSpawnableSpace.cs
+++ b/YouVsVirus/Assets/Scripts/Components/nonSpawnableSpace.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 
 // The nonSpawnableSpace class serves the purpose to
-// defines regions on the map that are non-spawnable.
+// define regions on the map that are non-spawnable.
 // Attach cirlceColliders to the game object that define
 // space where nothing should spawn.
 // If you then call the function coordinatesAreSpawnable2D with

--- a/YouVsVirus/Assets/Scripts/Components/nonSpawnableSpace.cs.meta
+++ b/YouVsVirus/Assets/Scripts/Components/nonSpawnableSpace.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 811f6eef37793e844aba40791ebb698f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/YouVsVirus/Assets/Scripts/levelgethome/CreatePopLevelgethome.cs
+++ b/YouVsVirus/Assets/Scripts/levelgethome/CreatePopLevelgethome.cs
@@ -94,12 +94,8 @@ namespace Components
             // place player near top left edge of the screen (using the not shrunk screen bounds)
             Vector2 coords;
             
-            // Create random coordinates and check whether they are spawnable
-            do
-            {
-                coords = new Vector2(-randomGridForHumans.screenBounds.x / 0.8f + 0.2f, randomGridForHumans.screenBounds.y / 0.8f - 0.2f);
-            }
-            while (!nonSpawnableSpaceClass.coordinatesAreSpawnable2D(coords));
+            // Create human in upper left corner
+            coords = new Vector2(-randomGridForHumans.screenBounds.x / 0.8f + 0.2f, randomGridForHumans.screenBounds.y / 0.8f - 0.2f);
 
             Vector3 coords3D = new Vector3 (coords[0], coords[1], 0);
             //  Place the player

--- a/YouVsVirus/Assets/Scripts/levelgethome/CreatePopLevelgethome.cs
+++ b/YouVsVirus/Assets/Scripts/levelgethome/CreatePopLevelgethome.cs
@@ -37,6 +37,10 @@ namespace Components
 
         private RandomGrid randomGridForHumans;
 
+        public GameObject nonSpawnableSpaceObj;
+
+        private nonSpawnableSpace nonSpawnableSpaceClass;
+
         /// <summary>
         /// Number of instantiated NPCs.
         /// </summary>
@@ -61,6 +65,8 @@ namespace Components
 
         void Start()
         {
+            // Get reference to the nonSpanableSpace class
+            nonSpawnableSpaceClass = nonSpawnableSpaceObj.GetComponent<nonSpawnableSpace>();
             // get active level settings - the get home scene always has 50% social distancing
             LevelSettings.GetActiveLevelSettings().SocialDistancingFactor = 18;
             LevelSettings.GetActiveLevelSettings().NumberOfNPCs = npcNumber;
@@ -75,7 +81,7 @@ namespace Components
             // and the number of humans that we want to place
             randomGridForHumans.GenerateRandomCoords(playerPrefab.transform.localScale.x,
                                                             playerPrefab.GetComponentInChildren<InfectionTrigger>().InfectionRadius,
-                                                            npcNumber);
+                                                            npcNumber, nonSpawnableSpaceClass);
             // place humans on grid
             CreateHumans();
         }
@@ -86,10 +92,19 @@ namespace Components
         private void CreateHumans()
         {
             // place player near top left edge of the screen (using the not shrunk screen bounds)
-            Vector3 coords = new Vector3(-randomGridForHumans.screenBounds.x / 0.8f + 0.2f, randomGridForHumans.screenBounds.y / 0.8f - 0.2f, 0f);
+            Vector2 coords;
+            
+            // Create random coordinates and check whether they are spawnable
+            do
+            {
+                coords = new Vector2(-randomGridForHumans.screenBounds.x / 0.8f + 0.2f, randomGridForHumans.screenBounds.y / 0.8f - 0.2f);
+            }
+            while (!nonSpawnableSpaceClass.coordinatesAreSpawnable2D(coords));
+
+            Vector3 coords3D = new Vector3 (coords[0], coords[1], 0);
             //  Place the player
             Player = Instantiate(playerPrefab.GetComponent<Player>(),
-                                 coords,
+                                 coords3D,
                                  Quaternion.identity);
             // give the player a unique id
             Player.myID = npcNumber;

--- a/YouVsVirus/ProjectSettings/EditorBuildSettings.asset
+++ b/YouVsVirus/ProjectSettings/EditorBuildSettings.asset
@@ -27,6 +27,12 @@ EditorBuildSettings:
     path: Assets/Scenes/EndScreenLevelsupermarket_1.unity
     guid: e4d3adc168e27f1418f5bbc623a30d4f
   - enabled: 1
+    path: Assets/Scenes/LevelCollectMasks/EndScreenLevelcollectmasks.unity
+    guid: cc22b6d4347f05b46a480a402e78f1cb
+  - enabled: 1
+    path: Assets/Scenes/LevelCollectMasks/YouVsVirus_Levelcollectmasks.unity
+    guid: abb8b2cb0675081409b4ec60e49b237a
+  - enabled: 1
     path: Assets/Scenes/EndScreenLevelsupermarket_2.unity
     guid: 3067c6d83b88f9d43a72e2e68ae1c3fb
   - enabled: 1

--- a/YouVsVirus/ProjectSettings/Physics2DSettings.asset
+++ b/YouVsVirus/ProjectSettings/Physics2DSettings.asset
@@ -53,4 +53,4 @@ Physics2DSettings:
   m_ColliderAsleepColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.36078432}
   m_ColliderContactColor: {r: 1, g: 0, b: 1, a: 0.6862745}
   m_ColliderAABBColor: {r: 1, g: 1, b: 0, a: 0.2509804}
-  m_LayerCollisionMatrix: fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffffdffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_LayerCollisionMatrix: ffbfffffffbfffffffbfffffffffffffffbfffffffbfffffffffffffffffffffffbfffffff97ffffff9fffffffadffffffb7ffffffb9ffffc880ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/YouVsVirus/ProjectSettings/TagManager.asset
+++ b/YouVsVirus/ProjectSettings/TagManager.asset
@@ -6,6 +6,7 @@ TagManager:
   tags:
   - Friend
   - NPC
+  - Mask
   layers:
   - Default
   - TransparentFX
@@ -19,9 +20,9 @@ TagManager:
   - Dancefloor
   - NPC
   - Player
-  - 
-  - 
-  - 
+  - CollideswithNPCbutnotPlayer
+  - Collectables
+  - DoesntCollideWithAnything
   - 
   - 
   - 
@@ -45,6 +46,9 @@ TagManager:
     locked: 0
   - name: Dead
     uniqueID: 2062951519
+    locked: 0
+  - name: Collectables
+    uniqueID: 3906036087
     locked: 0
   - name: Living
     uniqueID: 2061542899


### PR DESCRIPTION
This prefab can be equipped with circle colliders
that define space in which no NPC should spawn.
The RandomGrid and CreatePop scripts check their
coordinates and if they are in non-spawnable space
regenerate them.

Please check this out. Would love to hear your feedback on this and if this is a viable solution.
Unfortunately it is not very efficient if the area is large due to the way the grid coordinates are currently computed.