### PR TITLE
Add bool to levelsettings whether to show infection status or not

### DIFF
--- a/YouVsVirus/Assets/Scenes/Levelgethome/YouVsVirus_Levelgethome.unity
+++ b/YouVsVirus/Assets/Scenes/Levelgethome/YouVsVirus_Levelgethome.unity
@@ -963,11 +963,11 @@ EdgeCollider2D:
   m_Offset: {x: 0, y: 0}
   m_EdgeRadius: 0
   m_Points:
-  - {x: -8.874203, y: -5}
-  - {x: -8.874203, y: 5}
-  - {x: 8.874203, y: 5}
-  - {x: 8.874203, y: -5}
-  - {x: -8.874203, y: -5}
+  - {x: -8.888889, y: -5}
+  - {x: -8.888889, y: 5}
+  - {x: 8.888889, y: 5}
+  - {x: 8.888889, y: -5}
+  - {x: -8.888889, y: -5}
 --- !u!20 &519420031
 Camera:
   m_ObjectHideFlags: 0
@@ -987,9 +987,9 @@ Camera:
   m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
-    x: 0.00044605136
+    x: 0
     y: 0
-    width: 0.9991079
+    width: 1
     height: 1
   near clip plane: 0.3
   far clip plane: 1000
@@ -1600,7 +1600,6 @@ MonoBehaviour:
   IncubationTime: 20
   RecoveryRate: 0.1
   DeathRate: 0.02
-  DayLength: 1
 --- !u!4 &934205704
 Transform:
   m_ObjectHideFlags: 0

--- a/YouVsVirus/Assets/Scripts/Components/HumanBase.cs
+++ b/YouVsVirus/Assets/Scripts/Components/HumanBase.cs
@@ -135,7 +135,7 @@ namespace Components
             }
 
             // in Levelgethome we want all the smileys to stay the same except for the player
-            if(LevelSettings.GetActiveLevelSettings().ShowInfectinoStatus == true || this.tag == "Player" )
+            if(LevelSettings.GetActiveLevelSettings().ShowInfectionStatus == true || this.tag == "Player" )
             {
                 // Update the sprite image
                 UpdateSpriteImage();

--- a/YouVsVirus/Assets/Scripts/Components/HumanBase.cs
+++ b/YouVsVirus/Assets/Scripts/Components/HumanBase.cs
@@ -135,7 +135,7 @@ namespace Components
             }
 
             // in Levelgethome we want all the smileys to stay the same except for the player
-            if(LevelSettings.GetActiveSceneName() != "YouVsVirus_Levelgethome" || this.tag == "Player" )
+            if(LevelSettings.GetActiveLevelSettings().ShowInfectinoStatus == true || this.tag == "Player" )
             {
                 // Update the sprite image
                 UpdateSpriteImage();

--- a/YouVsVirus/Assets/Scripts/Components/InfectionControl.cs
+++ b/YouVsVirus/Assets/Scripts/Components/InfectionControl.cs
@@ -30,22 +30,7 @@ public class  InfectionControl : MonoBehaviour
     /// </summary>
     public float DeathRate = 0.02f;
 
-    /// <summary>
-    /// The length of a simulated day in seconds.
-    /// </summary>
-    public float DayLength = 1f;
-
-
     private float lastDayTick = 0;
-
-    private void Start()
-    {
-        // in the get home scene time passes 100 times slower
-        if (LevelSettings.GetActiveSceneName() == "YouVsVirus_Levelgethome")
-        {
-            DayLength = 100f;
-        }
-    }
 
     /// <summary>
     ///  Runs after all other update calls, ensuring that lastDayTick gets updated AFTER all humans have called IsNewDay().
@@ -53,7 +38,7 @@ public class  InfectionControl : MonoBehaviour
     /// </summary>
     void LateUpdate()
     {
-        if(Time.time - lastDayTick > DayLength)
+        if(Time.time - lastDayTick > LevelSettings.GetActiveLevelSettings().DayLength)
         {
             lastDayTick = Time.time;
         }
@@ -66,6 +51,6 @@ public class  InfectionControl : MonoBehaviour
     /// <returns>true if a new day has begun, false otherwise.</returns>
     public bool IsNewDay()
     {
-        return Time.time - lastDayTick > DayLength;
+        return Time.time - lastDayTick > LevelSettings.GetActiveLevelSettings().DayLength;
     }
 }

--- a/YouVsVirus/Assets/Scripts/Components/LevelSettings.cs
+++ b/YouVsVirus/Assets/Scripts/Components/LevelSettings.cs
@@ -27,6 +27,11 @@ public class LevelSettings : MonoBehaviour
     public float SocialDistancingFactor = 50f;
 
     /// <summary>
+    /// Do we show the infection status of the smileys in this level or not.
+    /// </summary>
+    public bool ShowInfectinoStatus = true;
+
+    /// <summary>
     /// the current active scene
     /// </summary>
     private Scene scene;

--- a/YouVsVirus/Assets/Scripts/Components/LevelSettings.cs
+++ b/YouVsVirus/Assets/Scripts/Components/LevelSettings.cs
@@ -29,7 +29,7 @@ public class LevelSettings : MonoBehaviour
     /// <summary>
     /// Do we show the infection status of the smileys in this level or not.
     /// </summary>
-    public bool ShowInfectinoStatus = true;
+    public bool ShowInfectionStatus = true;
 
     /// <summary>
     /// the current active scene
@@ -87,4 +87,3 @@ public class LevelSettings : MonoBehaviour
         return ActiveEndLevelController;
     }
 }
-

--- a/YouVsVirus/Assets/Scripts/Components/LevelSettings.cs
+++ b/YouVsVirus/Assets/Scripts/Components/LevelSettings.cs
@@ -32,6 +32,11 @@ public class LevelSettings : MonoBehaviour
     public bool ShowInfectionStatus = true;
 
     /// <summary>
+    /// The length of a simulated day in seconds.
+    /// </summary>
+    public float DayLength = 1f;
+
+    /// <summary>
     /// the current active scene
     /// </summary>
     private Scene scene;

--- a/YouVsVirus/Assets/Scripts/levelgethome/CreatePopLevelgethome.cs
+++ b/YouVsVirus/Assets/Scripts/levelgethome/CreatePopLevelgethome.cs
@@ -66,6 +66,8 @@ namespace Components
             LevelSettings.GetActiveLevelSettings().NumberOfNPCs = npcNumber;
             // We do not show the infection status in this level
             LevelSettings.GetActiveLevelSettings().ShowInfectionStatus = false;
+            // Set the DayLength for this level
+            LevelSettings.GetActiveLevelSettings().DayLength = 100;
             // this gets the Main Camera from the Scene
             // the grid cell has to be as large as the player's infection radius
             randomGridForHumans = GameObject.Find("RandomGrid").GetComponent<RandomGrid>();

--- a/YouVsVirus/Assets/Scripts/levelgethome/CreatePopLevelgethome.cs
+++ b/YouVsVirus/Assets/Scripts/levelgethome/CreatePopLevelgethome.cs
@@ -65,7 +65,7 @@ namespace Components
             LevelSettings.GetActiveLevelSettings().SocialDistancingFactor = 18;
             LevelSettings.GetActiveLevelSettings().NumberOfNPCs = npcNumber;
             // We do not show the infection status in this level
-            LevelSettings.GetActiveLevelSettings().ShowInfectinoStatus = false;
+            LevelSettings.GetActiveLevelSettings().ShowInfectionStatus = false;
             // this gets the Main Camera from the Scene
             // the grid cell has to be as large as the player's infection radius
             randomGridForHumans = GameObject.Find("RandomGrid").GetComponent<RandomGrid>();

--- a/YouVsVirus/Assets/Scripts/levelgethome/CreatePopLevelgethome.cs
+++ b/YouVsVirus/Assets/Scripts/levelgethome/CreatePopLevelgethome.cs
@@ -44,7 +44,7 @@ namespace Components
 
         public CreatePopLevelgethome()
         {
-            NPCs = new List<NPC>(42);
+            NPCs = new List<NPC>(npcNumber);
         }
 
         /// <summary>
@@ -64,6 +64,8 @@ namespace Components
             // get active level settings - the get home scene always has 50% social distancing
             LevelSettings.GetActiveLevelSettings().SocialDistancingFactor = 18;
             LevelSettings.GetActiveLevelSettings().NumberOfNPCs = npcNumber;
+            // We do not show the infection status in this level
+            LevelSettings.GetActiveLevelSettings().ShowInfectinoStatus = false;
             // this gets the Main Camera from the Scene
             // the grid cell has to be as large as the player's infection radius
             randomGridForHumans = GameObject.Find("RandomGrid").GetComponent<RandomGrid>();


### PR DESCRIPTION
This makes it more feasible for levels different then gethome
to have their infection status shown or not

Also got rid of magic number on NPC creation.