### PR TITLE
Johannes/#142 vertical movement speed

### DIFF
--- a/YouVsVirus/Assets/Scripts/Components/Player.cs
+++ b/YouVsVirus/Assets/Scripts/Components/Player.cs
@@ -90,8 +90,14 @@ namespace Components
 
 		private void ProcessMovementInput()
 		{
-			// What is the player doing?
-			Vector3 move = new Vector3(Input.GetAxis("Horizontal"), Input.GetAxis("Vertical"), 0) * speedMultiplier;
+			// Get the input via the horizontal and vertical axis
+			Vector2 rawMove =  new Vector3(Input.GetAxis("Horizontal"), Input.GetAxis("Vertical"), 0);
+			// If this input is too large, we normalize it
+			if (rawMove.magnitude > 1) {
+				rawMove.Normalize ();
+			}
+			// Scale this movement with the speed
+			Vector2 move = rawMove * speedMultiplier;
 
 			// Find the rigidbody, update its velocity and let the physics engine do the rest.
 			myRigidbody.velocity = move;

--- a/YouVsVirus/Assets/Scripts/Components/Player.cs
+++ b/YouVsVirus/Assets/Scripts/Components/Player.cs
@@ -17,7 +17,7 @@ namespace Components
 		/// <summary>
 		/// // The player's input vector will be multiplied by this factor
 		/// </summary>
-		public float speedMultiplier = 5.0f;
+		public float speedMultiplier = 6.0f;
 
 		/// <summary>
 		/// How many masks the player has collected


### PR DESCRIPTION
This is a short commit, only 2 lines.

The movement speed is normalized when the Input Vector has magnitude > 1.
Thus, all directions have the same speed now.

Also increased the base speed a bit, since the game felt much slower now.

The code is easy, but please check whether the speed feels right and may need adjustment.